### PR TITLE
Add appointment tests for missing and past date validations

### DIFF
--- a/src/base/base_page.py
+++ b/src/base/base_page.py
@@ -1,5 +1,7 @@
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import Select
+
 
 class BasePage:
     def __init__(self, driver):
@@ -23,4 +25,7 @@ class BasePage:
     def wait_for_element(self, by_locator):
         return WebDriverWait(self.driver, self.timeout).until(EC.visibility_of_element_located(by_locator))
 
-    
+    def select_dropdown(self, locator, visible_text):
+        element = self.driver.find_element(*locator)
+        dropdown = Select(element)
+        dropdown.select_by_visible_text(visible_text)

--- a/src/pageObjects/appointment_page.py
+++ b/src/pageObjects/appointment_page.py
@@ -1,0 +1,31 @@
+from selenium.webdriver.common.by import By
+from src.base.base_page import BasePage
+
+class AppointmentPage(BasePage):
+    FACILITY_DROPDOWN = (By.ID, "combo_facility")
+    APPLY_CHECKBOX = (By.ID, "chk_hospotal_readmission")
+    MEDICAID_RADIO = (By.ID, "radio_program_medicaid")
+    VISIT_DATE_INPUT = (By.ID, "txt_visit_date")
+    COMMENT_TEXTAREA = (By.ID, "txt_comment")
+    BOOK_BUTTON = (By.ID, "btn-book-appointment")
+
+    CONFIRMATION_MESSAGE = (By.XPATH, "//h2[contains(text(), 'Appointment Confirmation')]")
+
+    def __init__(self, driver):
+        super().__init__(driver)
+
+    def make_appointment(self, facility, readmission, program, visit_date, comment):
+        self.select_dropdown(self.FACILITY_DROPDOWN, facility)
+        if readmission:
+            self.click(self.APPLY_CHECKBOX)
+
+        if program.lower() == "medicaid":
+            self.click(self.MEDICAID_RADIO)
+
+        self.enter_text(self.VISIT_DATE_INPUT, visit_date)
+        self.enter_text(self.COMMENT_TEXTAREA, comment)
+        self.click(self.BOOK_BUTTON)
+
+    def is_appointment_confirmed(self):
+        return self.is_visible(self.CONFIRMATION_MESSAGE)
+

--- a/tests/test_invalid_appointment.py
+++ b/tests/test_invalid_appointment.py
@@ -1,0 +1,46 @@
+from src.pageObjects.login_page import LoginPage
+from src.pageObjects.appointment_page import AppointmentPage
+from selenium.common.exceptions import TimeoutException
+
+def test_appointment_missing_date(browser):
+    login = LoginPage(browser)
+    login.do_login("John Doe", "ThisIsNotAPassword")
+
+    appointment = AppointmentPage(browser)
+    appointment.make_appointment(
+        facility="Tokyo CURA Healthcare Center",
+        readmission=False,
+        program="Medicaid",
+        visit_date="",  # Intentionally left blank
+        comment="No visit date"
+    )
+
+    # This will try to find the confirmation page
+    try:
+        confirmed = appointment.is_appointment_confirmed()
+        assert not confirmed, "Confirmation should not appear when visit date is missing."
+    except TimeoutException:
+        # Timeout means confirmation didn't appear = expected ✅
+        assert True
+
+
+def test_appointment_with_past_date(browser):
+    login = LoginPage(browser)
+    login.do_login("John Doe", "ThisIsNotAPassword")
+
+    appointment = AppointmentPage(browser)
+    appointment.make_appointment(
+        facility="Tokyo CURA Healthcare Center",
+        readmission=False,
+        program="Medicaid",
+        visit_date="01/01/2020",  # Past date
+        comment="Testing with past date"
+    )
+
+    # Check if confirmation is wrongly shown
+    try:
+        confirmed = appointment.is_appointment_confirmed()
+        assert not confirmed, "BUG: Appointment got confirmed with a past date."
+    except TimeoutException:
+        # This is expected if appointment is rejected properly
+        assert True

--- a/tests/test_make_appointment.py
+++ b/tests/test_make_appointment.py
@@ -1,0 +1,17 @@
+from src.pageObjects.login_page import LoginPage
+from src.pageObjects.appointment_page import AppointmentPage
+
+def test_make_appointment(browser):
+    login = LoginPage(browser)
+    login.do_login("John Doe", "ThisIsNotAPassword")
+
+    Appoinment = AppointmentPage(browser)
+    Appoinment.make_appointment(
+        facility="Hongkong CURA Healthcare Center",
+        readmission=True,
+        program="Medicaid",
+        visit_date="01/01/2026",
+        comment="This is a test appointment"
+    )
+
+    assert Appoinment.is_appointment_confirmed(), "Appointment was not confirmed successfully"


### PR DESCRIPTION
## ✅ Appointment Page Test Scenarios

### 📌 What’s Added:
- Created `AppointmentPage` class using Page Object Model (POM)
- Implemented test cases in `test_invalid_appointment.py`:
  - ❌ `test_appointment_missing_date` – Ensures appointments can't be booked without selecting a date
  - ❌ `test_appointment_with_past_date` – Validates that past dates are accepted for appointments

### 📊 Test Strategy:
- Used `try-except` to catch timeout when confirmation is **not shown** (expected behavior)
- Asserts that confirmation should **not** appear for invalid inputs

### 🔗 Supporting Resources:
- 📄 [Test Case Sheet](https://docs.google.com/spreadsheets/d/1u1D_edGypI42bUBoMOv3sp4Lmf7ZF5Sa8tDEczFrPkQ/edit?usp=sharing)
- 🐞 [Bug Log Sheet](https://docs.google.com/spreadsheets/d/12hu5az49L_z8AIFxuuY135ZW3dB7unPwVQInc3dOGAk/edit?usp=sharing)
